### PR TITLE
Disable autoclosing of liquid tags

### DIFF
--- a/lib/sliq.rb
+++ b/lib/sliq.rb
@@ -32,14 +32,9 @@ module Sliq
 
   class Tags < Slim::Filter
     def on_liquid_tag(name, args, block)
-      if empty_exp?(block)
-        [:static, "{% #{name} #{args} %}"]
-      else
-        [:multi,
-         [:static, "{% #{name} #{args} %}\n"],
-         block,
-         [:static, "\n{% end#{name} %}"]]
-      end
+      expr = [:static, "{% #{name} #{args} %}"]
+      expr = [:multi, expr, block ] unless empty_exp?(block)
+      expr
     end
   end
 


### PR DESCRIPTION
The current implementation does not support `else` for `for` and `if` tags and `case` for `when`.
We could try to add special cases but liquid allows registration of custom blocks that could allow even other branches. 
However we can not  predict all possible cases. 
With this fix an if condition would be written as follows

```
  % if page.author
    | {{ page.author }}
  % else
    | anonymous
  % endif
```

As you can see we now have to write endif explicitly but this cant be avoided because of the reasons above.
